### PR TITLE
Added a while loop inside the Reset() method to prevent all predicates from being true on initialisation

### DIFF
--- a/Assets/Scripts/Field.cs
+++ b/Assets/Scripts/Field.cs
@@ -43,16 +43,20 @@ public class Field : MonoBehaviour {
     public void Reset()
     {
         AddLetters(numLetters);
-        CreateExpressions();
-        DisplayPredicates();
-        for (int x = 0; x < boardSize; x++)
+        do
         {
-            for (int y = 0; y < boardSize; y++)
+            CreateExpressions();
+            DisplayPredicates();
+            for (int x = 0; x < boardSize; x++)
             {
-                fieldSlots[x, y].Reset();
+                for (int y = 0; y < boardSize; y++)
+                {
+                    fieldSlots[x, y].Reset();
+                }
             }
-        }
-        Evaluate();
+
+            Evaluate();
+        } while (this.winner.activeSelf);
     }
 
 


### PR DESCRIPTION
Currently on generating a new random predicates, it might happen that all predicates turn out to be true, without the user doing anything. This adds a simple loop to prevent all from being true. This is done by looking at the visibility of the `this.winner Gameobject`.